### PR TITLE
Support electron build on Windows

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -17,7 +17,9 @@ module.exports = {
     makers: [
         {
             name: "@electron-forge/maker-squirrel",
-            config: {},
+            config: {
+                name: "open-rmbt-desktop",
+            },
         },
         {
             name: "@electron-forge/maker-zip",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "node": ">=18"
     },
     "scripts": {
-        "build:all": "webpack --mode production && cd src/ui && npm run build-for-packaging && cp -rf dist/ui/* ../../dist",
+        "build:all": "webpack --mode production && cd src/ui && npm run build-for-packaging && shx cp -rf dist/ui/* ../../dist",
         "start:cli": "webpack --mode development --config ./webpack.cli.config.js && npx ts-node src/cli/cli.ts",
         "start:electron": "npx tsc && cross-env DEV=true electron dist/electron/electron.js",
         "start:ui": "(cd src/ui && npm run start)",
@@ -39,7 +39,8 @@
         "ts-node": "^10.7.0",
         "typescript": "^4.6.4",
         "webpack": "^5.74.0",
-        "webpack-cli": "^4.10.0"
+        "webpack-cli": "^4.10.0",
+        "shx": "^0.3.4"
     },
     "dependencies": {
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "open-rmbt-desktop",
     "version": "0.0.1",
-    "description": "",
+    "description": "open-rmbt-desktop application",
     "main": "dist/main.js",
     "engines": {
         "node": ">=18"
@@ -33,14 +33,14 @@
         "dotenv-webpack": "^8.0.1",
         "electron": "^21.2.0",
         "node-loader": "^2.0.0",
+        "shx": "^0.3.4",
         "start-server-and-test": "^1.14.0",
         "terser-webpack-plugin": "^5.3.6",
         "ts-loader": "^9.4.1",
         "ts-node": "^10.7.0",
         "typescript": "^4.6.4",
         "webpack": "^5.74.0",
-        "webpack-cli": "^4.10.0",
-        "shx": "^0.3.4"
+        "webpack-cli": "^4.10.0"
     },
     "dependencies": {
         "axios": "^0.27.2",

--- a/src/electron/protocol.js
+++ b/src/electron/protocol.js
@@ -48,7 +48,7 @@ function mime(filename) {
 function requestHandler(req, next) {
     const reqUrl = new URL(req.url)
     let reqPath = path.normalize(reqUrl.pathname)
-    if (reqPath === "/") {
+    if (reqPath === "/" || reqPath === "\\") {
         reqPath = "/index.html"
     }
     const reqFilename = path.basename(reqPath)


### PR DESCRIPTION
On Windows, `cp` is not available, leading to a fail in build.
Also, `path.normalize` will still return a backslash on Windows systems. As then in electron startup, the index is not found, this leads to an `illegal operation on a directory` error message.